### PR TITLE
Update AboutUs

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -56,6 +56,7 @@ You can reach us at the email `seer[at]comp.nus.edu.sg`
 <img src="images/sampy147.png" width="200px">
 
 [[github](http://github.com/Sampy147)]
+[[portfolio](team/sampy147.md)]
 
 * Role: Developer
 * Responsibilities: Documentation and Code quality


### PR DESCRIPTION
AboutUs page lacked the github portfolio details for sampy147. Rectified the AboutUs page to include these details.