### PR TITLE
Add delete task command and delete module command features

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -11,5 +11,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d tasks listed!";
-
+    public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
+    public static final String MESSAGE_INVALID_MODULE_DISPLAYED_INDEX = "The module index provided is invalid";
+    public static final String MESSAGE_INVALID_MODULE_DELETION_AS_TIED_WITH_TASK
+            = "The module cannot be deleted as it is tied with an existing task";
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -11,8 +11,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d tasks listed!";
-    public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
     public static final String MESSAGE_INVALID_MODULE_DISPLAYED_INDEX = "The module index provided is invalid";
-    public static final String MESSAGE_INVALID_MODULE_DELETION_AS_TIED_WITH_TASK
-            = "The module cannot be deleted as it is tied with an existing task";
+    public static final String MESSAGE_INVALID_MODULE_DELETION_AS_TIED_WITH_TASK = "The module"
+            + "cannot be deleted as it is tied with an existing task";
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d tasks listed!";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
@@ -8,8 +8,6 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.Person;
-import seedu.address.model.task.Task;
 import seedu.address.model.module.Module;
 
 /**

--- a/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
@@ -1,0 +1,60 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.task.Task;
+import seedu.address.model.module.Module;
+
+/**
+ * Deletes a person identified using it's displayed index from the address book.
+ */
+public class DeleteModuleCommand extends Command {
+
+    public static final String COMMAND_WORD = "deletemodule";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the module identified by the index number used in the displayed module list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_MODULE_SUCCESS = "Deleted Module: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteModuleCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Module> lastShownList = model.getFilteredModuleList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MODULE_DISPLAYED_INDEX);
+        }
+
+        Module moduleToDelete = lastShownList.get(targetIndex.getZeroBased());
+
+        if (model.hasTaskWithModule(moduleToDelete)) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MODULE_DELETION_AS_TIED_WITH_TASK);
+        }
+
+        model.deleteModule(moduleToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_MODULE_SUCCESS, moduleToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteModuleCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteModuleCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.task.Task;
+
+/**
+ * Deletes a person identified using it's displayed index from the address book.
+ */
+public class DeleteTaskCommand extends Command {
+
+    public static final String COMMAND_WORD = "deletetask";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the task identified by the index number used in the displayed task list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_TASK_SUCCESS = "Deleted Task: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteTaskCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Task> lastShownList = model.getFilteredTaskList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+        }
+
+        Task taskToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteTask(taskToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_TASK_SUCCESS, taskToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteTaskCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteTaskCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -8,7 +8,6 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.Person;
 import seedu.address.model.task.Task;
 
 /**

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.task.Task;
+
+/**
+ * Mark a task identified using it's displayed index from the task list as complete.
+ */
+public class MarkCommand extends Command {
+
+    public static final String COMMAND_WORD = "mark";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Marks the task identified by the index number used in the displayed task list.\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_MARK_TASK_SUCCESS = "Marked Task: %1$s";
+
+    private final Index targetIndex;
+
+    public MarkCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Task> lastShownList = model.getFilteredTaskList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+        }
+
+        Task taskToMark = lastShownList.get(targetIndex.getZeroBased());
+        Task markedTask = taskToMark.mark();
+        model.setTask(taskToMark, markedTask);
+
+        return new CommandResult(String.format(MESSAGE_MARK_TASK_SUCCESS, taskToMark));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof MarkCommand // instanceof handles nulls
+            && targetIndex.equals(((MarkCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FindTasksCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListTasksCommand;
+import seedu.address.logic.commands.MarkCommand;
 import seedu.address.logic.commands.TaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -56,6 +57,9 @@ public class AddressBookParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
+        case MarkCommand.COMMAND_WORD:
+            return new MarkCommandParser().parse(arguments);
 
         case AddModuleCommand.COMMAND_WORD:
             return new AddModuleCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+<<<<<<< HEAD
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddModuleCommand;
 import seedu.address.logic.commands.ClearCommand;
@@ -20,6 +21,9 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListTasksCommand;
 import seedu.address.logic.commands.MarkCommand;
 import seedu.address.logic.commands.TaskCommand;
+=======
+import seedu.address.logic.commands.*;
+>>>>>>> adding-delete-command
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -87,6 +91,12 @@ public class AddressBookParser {
 
         case TaskCommand.COMMAND_WORD:
             return new TaskCommandParser().parse(arguments);
+
+        case DeleteTaskCommand.COMMAND_WORD:
+            return new DeleteTaskCommandParser().parse(arguments);
+
+        case DeleteModuleCommand.COMMAND_WORD:
+            return new DeleteModuleCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,12 +6,13 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-<<<<<<< HEAD
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddModuleCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteModuleCommand;
+import seedu.address.logic.commands.DeleteTaskCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -21,9 +22,6 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListTasksCommand;
 import seedu.address.logic.commands.MarkCommand;
 import seedu.address.logic.commands.TaskCommand;
-=======
-import seedu.address.logic.commands.*;
->>>>>>> adding-delete-command
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/DeleteModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteModuleCommandParser.java
@@ -4,7 +4,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteModuleCommand;
-import seedu.address.logic.commands.DeleteTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/DeleteModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteModuleCommandParser.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteModuleCommand;
+import seedu.address.logic.commands.DeleteTaskCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteModuleCommand object
+ */
+public class DeleteModuleCommandParser implements Parser<DeleteModuleCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteModuleCommand
+     * and returns a DeleteModuleCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteModuleCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteModuleCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteModuleCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteTaskCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteTaskCommand object
+ */
+public class DeleteTaskCommandParser implements Parser<DeleteTaskCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteTaskCommand
+     * and returns a DeleteTaskCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteTaskCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteTaskCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTaskCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.MarkCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new MarkCommand object
+ */
+public class MarkCommandParser implements Parser<MarkCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the MarkCommand
+     * and returns a MarkCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public MarkCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new MarkCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -105,6 +105,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     public void removePerson(Person key) {
         persons.remove(key);
     }
+
     public void addModule(Module mod) {
         modules.addModule(mod);
     }
@@ -117,6 +118,10 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean hasTask(Task task) {
         requireNonNull(task);
         return tasks.contains(task);
+    }
+
+    public boolean hasTaskWithModule(Module module) {
+        return tasks.containsModule(module);
     }
 
     /**
@@ -140,6 +145,14 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     public void setTasks(List<Task> tasks) {
         this.tasks.setTasks(tasks);
+    }
+
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeTask(Task key) {
+        tasks.remove(key);
     }
 
     //// util methods
@@ -166,6 +179,16 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(module);
         return modules.containsModule(module);
     }
+
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     * {@code key} must not be tied to any tasks in the address book.
+     */
+    public void removeModule(Module key) {
+        modules.remove(key);
+    }
+
     @Override
     public ObservableList<Module> getModuleList() {
         return modules.getUnmodifiableModuleList();

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.List;
 
@@ -124,6 +125,17 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void addTask(Task task) {
         tasks.addTask(task);
+    }
+
+    /**
+     * Replaces the given task {@code target} in the list with {@code editedTask}.
+     * {@code target} must exist in the task list.
+     * The task identity of {@code editedTask} must be the same as task identity of {@code target}.
+     */
+    public void setTask(Task target, Task editedTask) {
+        requireAllNonNull(target, editedTask);
+
+        tasks.setTask(target, editedTask);
     }
 
     public void setTasks(List<Task> tasks) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -101,6 +101,11 @@ public interface Model {
     boolean hasTask(Task task);
 
     /**
+     * Returns true if a task with {@code module} exists in the task list.
+     */
+    boolean hasTaskWithModule(Module module);
+
+    /**
      * Adds the given task.
      * {@code task} must not already exist in the task list.
      */
@@ -117,6 +122,18 @@ public interface Model {
     ObservableList<Task> getFilteredTaskList();
 
     boolean hasModule(Module module);
+
+    /**
+     * Deletes the given task.
+     * The task must exist in the address book.
+     */
+    void deleteTask(Task target);
+
+    /**
+     * Deletes the given module.
+     * The module must exist in the address book.
+     */
+    void deleteModule(Module target);
 
     /**
      * Updates the filter of the filtered task list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -106,6 +106,13 @@ public interface Model {
      */
     void addTask(Task task);
 
+    /**
+     * Replaces the given task {@code target} with {@code editedTask}.
+     * {@code target} must exist in the task list.
+     * The task identity of {@code editedTask} must be the same as task identity of {@code target}.
+     */
+    void setTask(Task target, Task editedTask);
+
     /** Returns an unmodifiable view of the filtered task list */
     ObservableList<Task> getFilteredTaskList();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -129,6 +129,13 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasTaskWithModule(Module module) {
+        requireNonNull(module);
+        return addressBook.hasTaskWithModule(module);
+    }
+
+
+    @Override
     public void addTask(Task task) {
         addressBook.addTask(task);
         updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
@@ -141,6 +148,11 @@ public class ModelManager implements Model {
         addressBook.setTask(target, editedTask);
     }
 
+    @Override
+    public void deleteTask(Task target) {
+        addressBook.removeTask(target);
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**
@@ -151,8 +163,6 @@ public class ModelManager implements Model {
     public ObservableList<Person> getFilteredPersonList() {
         return filteredPersons;
     }
-
-
 
     @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
@@ -176,6 +186,11 @@ public class ModelManager implements Model {
     @Override
     public ObservableList<Module> getFilteredModuleList() {
         return moduleFilteredList;
+    }
+
+    @Override
+    public void deleteModule(Module target) {
+        addressBook.removeModule(target);
     }
 
     //================================Task Commands=====================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -134,6 +134,13 @@ public class ModelManager implements Model {
         updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
     }
 
+    @Override
+    public void setTask(Task target, Task editedTask) {
+        requireAllNonNull(target, editedTask);
+
+        addressBook.setTask(target, editedTask);
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/module/DistinctModuleList.java
+++ b/src/main/java/seedu/address/model/module/DistinctModuleList.java
@@ -10,8 +10,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.module.exceptions.DuplicateModuleException;
 import seedu.address.model.module.exceptions.ModuleNotFoundException;
-import seedu.address.model.task.Task;
-import seedu.address.model.task.exceptions.TaskNotFoundException;
 
 /**
  * This class represents a list which contains Module objects which are distinct from

--- a/src/main/java/seedu/address/model/module/DistinctModuleList.java
+++ b/src/main/java/seedu/address/model/module/DistinctModuleList.java
@@ -9,6 +9,9 @@ import java.util.List;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.module.exceptions.DuplicateModuleException;
+import seedu.address.model.module.exceptions.ModuleNotFoundException;
+import seedu.address.model.task.Task;
+import seedu.address.model.task.exceptions.TaskNotFoundException;
 
 /**
  * This class represents a list which contains Module objects which are distinct from
@@ -49,6 +52,17 @@ public class DistinctModuleList implements Iterable<Module> {
     public void setModules(List<Module> modules) {
         requireAllNonNull(modules);
         moduleList.setAll(modules);
+    }
+
+    /**
+     * Removes the equivalent module from the module list.
+     * The module must exist in the list.
+     */
+    public void remove(Module toRemove) {
+        requireNonNull(toRemove);
+        if (!moduleList.remove(toRemove)) {
+            throw new ModuleNotFoundException();
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/module/exceptions/ModuleNotFoundException.java
+++ b/src/main/java/seedu/address/model/module/exceptions/ModuleNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.address.model.module.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified module.
+ */
+public class ModuleNotFoundException extends RuntimeException {}

--- a/src/main/java/seedu/address/model/task/DistinctTaskList.java
+++ b/src/main/java/seedu/address/model/task/DistinctTaskList.java
@@ -8,9 +8,11 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+
 import seedu.address.model.task.exceptions.DuplicateTaskException;
 import seedu.address.model.task.exceptions.TaskIdentityModifiedException;
 import seedu.address.model.task.exceptions.TaskNotFoundException;
+import seedu.address.model.module.Module;
 
 /**
  * This class represents a list which contains Tasks objects which are distinct from
@@ -32,6 +34,14 @@ public class DistinctTaskList implements Iterable<Task> {
     }
 
     /**
+     * Returns true if the list contains a task with an equivalent module as the given argument.
+     */
+    public boolean containsModule(Module toCheck) {
+        requireNonNull(toCheck);
+        return taskList.stream().map(Task::getModule).anyMatch(toCheck::isSameModuleCode);
+    }
+
+    /**
      * Adds the task to the taskList.
      * The task must not already exist in the list.
      *
@@ -47,6 +57,7 @@ public class DistinctTaskList implements Iterable<Task> {
     }
 
     /**
+<<<<<<< HEAD
      * Replaces the task {@code target} in the list with {@code editedTask}.
      * {@code target} must exist in the list.
      * The task identity of {@code editedTask} should be the same as task identity of {@code target}.
@@ -64,6 +75,17 @@ public class DistinctTaskList implements Iterable<Task> {
         }
 
         taskList.set(index, editedTask);
+    }
+
+    /**
+     * Removes the equivalent task from the tasklist.
+     * The task must exist in the list.
+     */
+    public void remove(Task toRemove) {
+        requireNonNull(toRemove);
+        if (!taskList.remove(toRemove)) {
+            throw new TaskNotFoundException();
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/DistinctTaskList.java
+++ b/src/main/java/seedu/address/model/task/DistinctTaskList.java
@@ -1,6 +1,7 @@
 package seedu.address.model.task;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
@@ -8,6 +9,8 @@ import java.util.List;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.task.exceptions.DuplicateTaskException;
+import seedu.address.model.task.exceptions.TaskIdentityModifiedException;
+import seedu.address.model.task.exceptions.TaskNotFoundException;
 
 /**
  * This class represents a list which contains Tasks objects which are distinct from
@@ -41,6 +44,26 @@ public class DistinctTaskList implements Iterable<Task> {
             throw new DuplicateTaskException();
         }
         taskList.add(taskAdded);
+    }
+
+    /**
+     * Replaces the task {@code target} in the list with {@code editedTask}.
+     * {@code target} must exist in the list.
+     * The task identity of {@code editedTask} should be the same as task identity of {@code target}.
+     */
+    public void setTask(Task target, Task editedTask) {
+        requireAllNonNull(target, editedTask);
+
+        int index = taskList.indexOf(target);
+        if (index == -1) {
+            throw new TaskNotFoundException();
+        }
+
+        if (!target.isSameTask(editedTask)) {
+            throw new TaskIdentityModifiedException();
+        }
+
+        taskList.set(index, editedTask);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/DistinctTaskList.java
+++ b/src/main/java/seedu/address/model/task/DistinctTaskList.java
@@ -8,11 +8,10 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-
+import seedu.address.model.module.Module;
 import seedu.address.model.task.exceptions.DuplicateTaskException;
 import seedu.address.model.task.exceptions.TaskIdentityModifiedException;
 import seedu.address.model.task.exceptions.TaskNotFoundException;
-import seedu.address.model.module.Module;
 
 /**
  * This class represents a list which contains Tasks objects which are distinct from
@@ -57,7 +56,6 @@ public class DistinctTaskList implements Iterable<Task> {
     }
 
     /**
-<<<<<<< HEAD
      * Replaces the task {@code target} in the list with {@code editedTask}.
      * {@code target} must exist in the list.
      * The task identity of {@code editedTask} should be the same as task identity of {@code target}.

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -11,6 +11,7 @@ import seedu.address.model.module.Module;
 public class Task {
     private final Module module;
     private final TaskDescription description;
+    private TaskStatus status;
 
     /**
      * The constructor of the Task class. Sets the module and
@@ -22,16 +23,32 @@ public class Task {
     public Task(Module module, TaskDescription description) {
         this.module = module;
         this.description = description;
+        this.status = TaskStatus.INCOMPLETE;
     }
 
+    /**
+     * The constructor of the Task class. Sets the module and
+     * description of the task.
+     *
+     * @param module The module being added.
+     * @param description The description of the task.
+     */
+    public Task(Module module, TaskDescription description, TaskStatus status) {
+        this.module = module;
+        this.description = description;
+        this.status = status;
+    }
 
     public TaskDescription getDescription() {
         return description;
     }
 
-
     public Module getModule() {
         return module;
+    }
+
+    public TaskStatus getStatus() {
+        return status;
     }
 
     /**
@@ -39,6 +56,21 @@ public class Task {
      */
     public boolean isSameTask(Task otherTask) {
         return this.equals(otherTask);
+    }
+
+    /**
+     * Returns true if task is complete.
+     */
+    public boolean isComplete() {
+        return this.status.isComplete();
+    }
+
+    /**
+     * Marks the task as complete
+     * and returns the task.
+     */
+    public Task mark() {
+        return new Task(module, description, TaskStatus.COMPLETE);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/TaskStatus.java
+++ b/src/main/java/seedu/address/model/task/TaskStatus.java
@@ -1,0 +1,79 @@
+package seedu.address.model.task;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * TaskStatus class represents the status of the task - whether it is complete.
+ */
+public class TaskStatus {
+
+    private static final String COMPLETE_STRING = "complete";
+    private static final String INCOMPLETE_STRING = "incomplete";
+
+    public static final TaskStatus COMPLETE = new TaskStatus(COMPLETE_STRING);
+    public static final TaskStatus INCOMPLETE = new TaskStatus(INCOMPLETE_STRING);
+
+    public static final String STATUS_CONSTRAINTS =
+        "The status of the task should be " + COMPLETE + " or " + INCOMPLETE;
+
+    public final String status;
+
+    private TaskStatus(String status) {
+        requireNonNull(status);
+        checkArgument(isValidStatus(status), STATUS_CONSTRAINTS);
+        this.status = status;
+    }
+
+    /**
+     * Constructs a {@code TaskStatus}.
+     * It is either complete or incomplete.
+     *
+     * @param status A valid status.
+     */
+    public static TaskStatus of(String status) {
+        if (status.equals(COMPLETE_STRING)) {
+            return COMPLETE;
+        } else {
+            return INCOMPLETE;
+        }
+    }
+
+    /**
+     * Returns true if the given string is a valid status,
+     * false otherwise.
+     *
+     * @param status string representation of a status.
+     * @return true if the given string is a valid status, false otherwise.
+     */
+    public static boolean isValidStatus(String status) {
+        return status.equals(COMPLETE_STRING) || status.equals(INCOMPLETE_STRING);
+    }
+
+    /**
+     * Returns true if task status is "complete",
+     * false otherwise.
+     *
+     * @return true if task status is "complete".
+     */
+    public boolean isComplete() {
+        return status.equals(COMPLETE_STRING);
+    }
+
+    @Override
+    public boolean equals(Object otherStatus) {
+        return otherStatus == this || (otherStatus instanceof TaskStatus
+            && status.equalsIgnoreCase((((TaskStatus) otherStatus).status)));
+    }
+
+    @Override
+    public int hashCode() {
+        return status.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return status;
+    }
+}
+

--- a/src/main/java/seedu/address/model/task/exceptions/TaskIdentityModifiedException.java
+++ b/src/main/java/seedu/address/model/task/exceptions/TaskIdentityModifiedException.java
@@ -1,0 +1,10 @@
+package seedu.address.model.task.exceptions;
+
+/**
+ * Signals that the operation will modify the identity of the task.
+ */
+public class TaskIdentityModifiedException extends RuntimeException {
+    public TaskIdentityModifiedException() {
+        super("Operation would change task identity");
+    }
+}

--- a/src/main/java/seedu/address/model/task/exceptions/TaskNotFoundException.java
+++ b/src/main/java/seedu/address/model/task/exceptions/TaskNotFoundException.java
@@ -1,0 +1,7 @@
+package seedu.address.model.task.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified task.
+ */
+public class TaskNotFoundException extends RuntimeException {
+}

--- a/src/main/java/seedu/address/model/task/exceptions/TaskNotFoundException.java
+++ b/src/main/java/seedu/address/model/task/exceptions/TaskNotFoundException.java
@@ -3,5 +3,9 @@ package seedu.address.model.task.exceptions;
 /**
  * Signals that the operation is unable to find the specified task.
  */
+<<<<<<< HEAD
 public class TaskNotFoundException extends RuntimeException {
 }
+=======
+public class TaskNotFoundException extends RuntimeException {}
+>>>>>>> adding-delete-command

--- a/src/main/java/seedu/address/model/task/exceptions/TaskNotFoundException.java
+++ b/src/main/java/seedu/address/model/task/exceptions/TaskNotFoundException.java
@@ -3,9 +3,6 @@ package seedu.address.model.task.exceptions;
 /**
  * Signals that the operation is unable to find the specified task.
  */
-<<<<<<< HEAD
 public class TaskNotFoundException extends RuntimeException {
 }
-=======
-public class TaskNotFoundException extends RuntimeException {}
->>>>>>> adding-delete-command
+

--- a/src/main/java/seedu/address/storage/JsonAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTask.java
@@ -7,6 +7,7 @@ import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.TaskDescription;
+import seedu.address.model.task.TaskStatus;
 
 /**
  * This class represents a Jackson friendly version of the Task.
@@ -15,6 +16,7 @@ public class JsonAdaptedTask {
     public static final String MISSING_TASK_DESCRIPTION = "Task description is not present";
     private final String description;
     private final String moduleCode;
+    private final String status;
 
     /**
      * Builds a {@code JsonAdaptedTask} with the description and module code.
@@ -23,9 +25,10 @@ public class JsonAdaptedTask {
      * @param moduleCode The module code of the task.
      */
     public JsonAdaptedTask(@JsonProperty("description") String description,
-            @JsonProperty("modCode") String moduleCode) {
+            @JsonProperty("modCode") String moduleCode, @JsonProperty("status") String status) {
         this.description = description;
         this.moduleCode = moduleCode;
+        this.status = status;
     }
 
     /**
@@ -36,6 +39,8 @@ public class JsonAdaptedTask {
     public JsonAdaptedTask(Task task) {
         description = task.getDescription().description;
         moduleCode = task.getModule().getModuleCode().moduleCode;
+        status = task.getStatus().status;
+
     }
 
     /**
@@ -45,7 +50,7 @@ public class JsonAdaptedTask {
      * @throws IllegalValueException if the task has invalid fields.
      */
     public Task toModelType() throws IllegalValueException {
-        if (description == null || moduleCode == null) {
+        if (description == null || moduleCode == null || status == null) {
             throw new IllegalValueException(MISSING_TASK_DESCRIPTION);
         }
         if (!TaskDescription.isValidDescription(description)) {
@@ -54,10 +59,15 @@ public class JsonAdaptedTask {
         if (!ModuleCode.isValidModuleCode(moduleCode)) {
             throw new IllegalValueException(ModuleCode.MODULE_CODE_CONSTRAINTS);
         }
+        if (!TaskStatus.isValidStatus(status)) {
+            throw new IllegalValueException(TaskStatus.STATUS_CONSTRAINTS);
+        }
         final TaskDescription taskDescription = new TaskDescription(description);
         final ModuleCode modCode = new ModuleCode(moduleCode);
         final Module module = new Module(modCode);
-        return new Task(module, taskDescription);
+        final TaskStatus taskStatus = TaskStatus.of(status);
+        Task task = new Task(module, taskDescription, taskStatus);
+        return task;
     }
 
 }

--- a/src/main/java/seedu/address/ui/TaskCard.java
+++ b/src/main/java/seedu/address/ui/TaskCard.java
@@ -1,6 +1,7 @@
 package seedu.address.ui;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
 import seedu.address.model.task.Task;
@@ -11,6 +12,9 @@ import seedu.address.model.task.Task;
  */
 public class TaskCard extends UiPart<Region> {
     private static final String FXML = "TaskListCard.fxml";
+
+    public final Task task;
+
     @FXML
     private Label id;
 
@@ -20,6 +24,9 @@ public class TaskCard extends UiPart<Region> {
     @FXML
     private Label moduleCode;
 
+    @FXML
+    private CheckBox isComplete;
+
     /**
      * Constructor of the TaskCard. Sets the task and the position.
      *
@@ -28,8 +35,10 @@ public class TaskCard extends UiPart<Region> {
      */
     public TaskCard(Task task, int position) {
         super(FXML);
+        this.task = task;
         id.setText(position + ". ");
         moduleCode.setText(task.getModule().getModuleCode().moduleCode);
         description.setText(task.getDescription().description);
+        isComplete.setSelected(task.isComplete());
     }
 }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -1,36 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
-        <Insets top="5" right="5" bottom="5" left="15" />
+        <Insets bottom="5" left="15" right="5" top="5" />
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
+      <HBox alignment="CENTER_LEFT" spacing="5">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
+            <CheckBox fx:id="completed" alignment="CENTER" contentDisplay="GRAPHIC_ONLY" mnemonicParsing="false" prefHeight="18.0" prefWidth="16.0">
+               <HBox.margin>
+                  <Insets />
+               </HBox.margin>
+            </CheckBox>
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
     </VBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/TaskListCard.fxml
+++ b/src/main/resources/view/TaskListCard.fxml
@@ -1,32 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane HBox.hgrow="ALWAYS">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
         </columnConstraints>
-        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0" style="-fx-background-color:
-        #6cd2d2; -fx-border-color:black; ">
+        <VBox alignment="CENTER_LEFT" minHeight="105" style="-fx-background-color:         #6cd2d2; -fx-border-color:black; " GridPane.columnIndex="0">
             <padding>
-                <Insets top="5" right="5" bottom="5" left="15" />
+                <Insets bottom="5" left="15" right="5" top="5" />
             </padding>
-            <HBox spacing="7" alignment="CENTER_LEFT" >
-                <Label fx:id="id" styleClass="cell_big_label" >
+            <HBox alignment="CENTER_LEFT" spacing="7">
+                <Label fx:id="id" styleClass="cell_big_label">
                     <minWidth>
                         <Region fx:constant="USE_PREF_SIZE" />
                     </minWidth>
                 </Label>
-                <Label fx:id="description" text="\$description" styleClass="cell_big_label"  />
+                <Label fx:id="description" styleClass="cell_big_label" text="\$description" />
+            <CheckBox fx:id="isComplete" mnemonicParsing="false" prefHeight="18.0" prefWidth="7.0" />
             </HBox>
             <Label fx:id="moduleCode" text="\$modCode" />
         </VBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
     </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -162,6 +162,21 @@ public class AddCommandTest {
         public void setTask(Task task, Task editedTask) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void deleteTask(Task target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteModule(Module target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasTaskWithModule(Module module) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
     /**
      * A Model stub that contains a single person.

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -65,6 +65,7 @@ public class AddCommandTest {
     /**
      * A default model stub that have all of the methods failing.
      */
+
     private class ModelStub implements Model {
         @Override
         public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
@@ -154,6 +155,11 @@ public class AddCommandTest {
 
         @Override
         public void addTask(Task task) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setTask(Task task, Task editedTask) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteModuleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteModuleCommandTest.java
@@ -1,22 +1,11 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import org.junit.jupiter.api.Test;
-
-import seedu.address.commons.core.Messages;
-import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.Person;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -101,9 +90,6 @@ public class DeleteModuleCommandTest {
     }
     */
 
-    /**
-     * Updates {@code model}'s filtered list to show no one.
-     */
     /*
     private void showNoPerson(Model model) {
         model.updateFilteredModuleList(p -> false);

--- a/src/test/java/seedu/address/logic/commands/DeleteModuleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteModuleCommandTest.java
@@ -1,0 +1,116 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code DeleteModuleCommand}.
+ */
+public class DeleteModuleCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    /*
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+
+        Module moduleToDelete = model.getFilteredModuleList().get(INDEX_FIRST_MODULE.getZeroBased());
+        DeleteModuleCommand deleteModuleCommand = new DeleteModuleCommand(INDEX_FIRST_MODULE);
+
+        String expectedMessage = String.format(DeleteModuleCommand.MESSAGE_DELETE_MODULE_SUCCESS, moduleToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteModule(moduleToDelete);
+
+        assertCommandSuccess(deleteModuleCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredModuleList().size() + 1);
+        DeleteModuleCommand deleteModuleCommand = new DeleteModuleCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteModuleCommand, model, Messages.MESSAGE_INVALID_MODULE_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+        showNoPerson(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showModuleAtIndex(model, INDEX_FIRST_MODULE);
+
+        Index outOfBoundIndex = INDEX_SECOND_MODULE;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getModuleList().size());
+
+        DeleteModuleCommand deleteModuleCommand = new DeleteModuleCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteModuleCommand, model, Messages.MESSAGE_INVALID_MODULE_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteModuleCommand deleteModuleFirstCommand = new DeleteModuleCommand(INDEX_FIRST_MODULE);
+        DeleteModuleCommand deleteModuleSecondCommand = new DeleteModuleCommand(INDEX_SECOND_MODULE);
+
+        // same object -> returns true
+        assertTrue(deleteModuleFirstCommand.equals(deleteModuleFirstCommand));
+
+        // same values -> returns true
+        DeleteModuleCommand deleteModuleFirstCommandCopy = new DeleteModuleCommand(INDEX_FIRST_MODULE);
+        assertTrue(deleteModuleFirstCommand.equals(deleteModuleFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteModuleFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteModuleFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(deleteModuleFirstCommand.equals(deleteModuleSecondCommand));
+    }
+    */
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    /*
+    private void showNoPerson(Model model) {
+        model.updateFilteredModuleList(p -> false);
+
+        assertTrue(model.getFilteredModuleList().isEmpty());
+    }
+    */
+
+
+}

--- a/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
@@ -1,22 +1,10 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import org.junit.jupiter.api.Test;
-
-import seedu.address.commons.core.Messages;
-import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.Person;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -101,9 +89,6 @@ public class DeleteTaskCommandTest {
     }
     */
 
-        /**
-         * Updates {@code model}'s filtered list to show no one.
-         */
     /*
     private void showNoPerson(Model model) {
         model.updateFilteredTaskList(p -> false);
@@ -111,6 +96,5 @@ public class DeleteTaskCommandTest {
         assertTrue(model.getFilteredTaskList().isEmpty());
     }
     */
-
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
@@ -1,0 +1,116 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code DeleteTaskCommand}.
+ */
+public class DeleteTaskCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    /*
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+
+        Task taskToDelete = model.getFilteredTaskList().get(INDEX_FIRST_PERSON.getZeroBased());
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(DeleteTaskCommand.MESSAGE_DELETE_TASK_SUCCESS, taskToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteTask(taskToDelete);
+
+        assertCommandSuccess(deleteTaskCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredTaskList().size() + 1);
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteTaskCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+        showNoPerson(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showTaskAtIndex(model, INDEX_FIRST_TASK);
+
+        Index outOfBoundIndex = INDEX_SECOND_TASK;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getTaskList().size());
+
+        DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteTaskCommand, model, Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteTaskCommand deleteTaskFirstCommand = new DeleteTaskCommand(INDEX_FIRST_TASK);
+        DeleteTaskCommand deleteTaskSecondCommand = new DeleteTaskCommand(INDEX_SECOND_TASK);
+
+        // same object -> returns true
+        assertTrue(deleteTaskFirstCommand.equals(deleteTaskFirstCommand));
+
+        // same values -> returns true
+        DeleteTaskCommand deleteTaskFirstCommandCopy = new DeleteTaskCommand(INDEX_FIRST_TASK);
+        assertTrue(deleteTaskFirstCommand.equals(deleteTaskFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteTaskFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteTaskFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(deleteTaskFirstCommand.equals(deleteTaskSecondCommand));
+    }
+    */
+
+        /**
+         * Updates {@code model}'s filtered list to show no one.
+         */
+    /*
+    private void showNoPerson(Model model) {
+        model.updateFilteredTaskList(p -> false);
+
+        assertTrue(model.getFilteredTaskList().isEmpty());
+    }
+    */
+
+
+}

--- a/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
@@ -1,0 +1,92 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code MarkCommand}.
+ */
+class MarkCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    /*
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Task taskToMark = model.getFilteredTaskList().get(INDEX_FIRST_PERSON.getZeroBased());
+        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_TASK_SUCCESS, taskToMark);
+
+        ModelManager expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        Task editedTaskToMark = expectedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        editedTaskToMark.mark();
+        assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        MarkCommand markCommand = new MarkCommand(outOfBoundIndex);
+
+        assertCommandFailure(markCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_TASK_SUCCESS, personToMark);
+
+        ModelManager expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
+        Person editedPersonToMark = expectedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        editedPersonToMark.mark();
+
+        assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        MarkCommand markCommand = new MarkCommand(outOfBoundIndex);
+
+        assertCommandFailure(markCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        MarkCommand markFirstCommand = new MarkCommand(INDEX_FIRST_PERSON);
+        MarkCommand markSecondCommand = new MarkCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(markFirstCommand.equals(markFirstCommand));
+
+        // same values -> returns true
+        MarkCommand markFirstCommandCopy = new MarkCommand(INDEX_FIRST_PERSON);
+        assertTrue(markFirstCommand.equals(markFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(markFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(markFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(markFirstCommand.equals(markSecondCommand));
+    }
+
+
+     */
+}


### PR DESCRIPTION
Added DeleteTaskCommand class and DeleteTaskCommandParser to handle the deletion of tasks.
Added DeleteModuleCommand class and DeleteModuleCommandParser to handle the deletion of modules.
Added a method `hasTaskWithModule(Module module)` to the Model interface, ModelManager class and AddressBook class to be determine whether a task in the task list has a given module argument.
Added a method `containsModule(Module module)` in the DistinctTaskList class to support the above method implementation.