### PR TITLE
Add Edit Module Command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -14,6 +14,9 @@ public class Messages {
     public static final String MESSAGE_INVALID_MODULE_DISPLAYED_INDEX = "The module index provided is invalid";
     public static final String MESSAGE_INVALID_MODULE_DELETION_AS_TIED_WITH_TASK = "The module"
             + "cannot be deleted as it is tied with an existing task";
+    public static final String MESSAGE_INVALID_MODULE_EDIT_AS_TIED_WITH_TASK = "The module"
+            + "cannot be edited as it is tied with an existing task";
     public static final String MESSAGE_DUPLICATE_TASK = "This task already exists in the task list";
     public static final String MESSAGE_MODULE_NOT_FOUND = "This module does not exist";
+    public static final String MESSAGE_DUPLICATE_MODULE = "This module already exists in the module list";
 }

--- a/src/main/java/seedu/address/logic/commands/EditModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditModuleCommand.java
@@ -1,0 +1,142 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MOD_CODE;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_MODULES;
+
+import java.util.List;
+import java.util.Optional;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.exceptions.DuplicateModuleException;
+
+/**
+ * Edits the task with the specified index number in the displayed task list.
+ */
+public class EditModuleCommand extends Command {
+
+    public static final String COMMAND_WORD = "editmodule";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the module code of the module identified "
+            + "by the index number used in the displayed module list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_MOD_CODE + "MODULE CODE] "
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_MOD_CODE + "cs2040 ";
+
+    public static final String MESSAGE_EDIT_MODULE_SUCCESS = "Edited Module: %1$s";
+    public static final String MESSAGE_MODULE_NOT_EDITED = "The provided fields are the same as the current module";
+    public static final String MESSAGE_NO_FIELDS_PROVIDED = "At module name to edit must be provided.";
+
+    private final Index index;
+    private final EditModuleDescriptor editModuleDescriptor;
+
+    /**
+     * @param index of the task in the filtered module list to edit
+     * @param editModuleDescriptor details to edit the module with
+     */
+    public EditModuleCommand(Index index, EditModuleDescriptor editModuleDescriptor) {
+        requireAllNonNull(index, editModuleDescriptor);
+
+        this.index = index;
+        this.editModuleDescriptor = editModuleDescriptor;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Module> lastShownList = model.getFilteredModuleList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MODULE_DISPLAYED_INDEX);
+        }
+
+        Module moduleToEdit = lastShownList.get(index.getZeroBased());
+        Module editedModule = moduleToEdit.edit(editModuleDescriptor);
+
+        if (model.hasTaskWithModule(moduleToEdit)) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MODULE_EDIT_AS_TIED_WITH_TASK);
+        }
+
+        if (moduleToEdit.isSameModuleCode(editedModule)) {
+            throw new CommandException(MESSAGE_MODULE_NOT_EDITED);
+        }
+
+        try {
+            model.replaceModule(moduleToEdit, editedModule);
+        } catch (DuplicateModuleException e) {
+            throw new CommandException(Messages.MESSAGE_DUPLICATE_MODULE);
+        }
+
+        model.updateFilteredModuleList(PREDICATE_SHOW_ALL_MODULES);
+        return new CommandResult(String.format(MESSAGE_EDIT_MODULE_SUCCESS, editedModule));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditModuleCommand)) {
+            return false;
+        }
+
+        // state check
+        EditModuleCommand e = (EditModuleCommand) other;
+        return index.equals(e.index)
+                && editModuleDescriptor.equals(e.editModuleDescriptor);
+    }
+
+    /**
+     * Stores the name to edit the module with. Each non-empty field value will replace the
+     * corresponding field value of the task.
+     */
+    public static class EditModuleDescriptor {
+        private ModuleCode moduleCode;
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(moduleCode);
+        }
+
+        public void setModuleCode(ModuleCode moduleCode) {
+            this.moduleCode = moduleCode;
+        }
+
+        public Optional<ModuleCode> getModuleCode() {
+            return Optional.ofNullable(moduleCode);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditModuleDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditModuleDescriptor e = (EditModuleDescriptor) other;
+
+            return moduleCode.equals(e.moduleCode);
+        }
+    }
+}
+

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteModuleCommand;
 import seedu.address.logic.commands.DeleteTaskCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditModuleCommand;
 import seedu.address.logic.commands.EditTaskCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FilterTasksCommand;
@@ -62,6 +63,9 @@ public class AddressBookParser {
 
         case EditTaskCommand.COMMAND_WORD:
             return new EditTaskCommandParser().parse(arguments);
+
+        case EditModuleCommand.COMMAND_WORD:
+            return new EditModuleCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/EditModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditModuleCommandParser.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.EditTaskCommand.MESSAGE_NO_FIELDS_PROVIDED;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MOD_CODE;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditModuleCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.ModuleCode;
+
+/**
+ * Parses input arguments and creates a new EditModuleCommand object.
+ */
+public class EditModuleCommandParser implements Parser<EditModuleCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditModuleCommand
+     * and returns an EditModuleCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditModuleCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_MOD_CODE);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditModuleCommand.MESSAGE_USAGE), pe);
+        }
+
+        EditModuleCommand.EditModuleDescriptor editModuleDescriptor = new EditModuleCommand.EditModuleDescriptor();
+
+        if (argMultimap.getValue(PREFIX_MOD_CODE).isPresent()) {
+            ModuleCode moduleCode = ParserUtil.parseModuleCode(argMultimap.getValue(PREFIX_MOD_CODE).get());
+            editModuleDescriptor.setModuleCode(moduleCode);
+        }
+
+        if (!editModuleDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(MESSAGE_NO_FIELDS_PROVIDED);
+        }
+        return new EditModuleCommand(index, editModuleDescriptor);
+    }
+
+}
+

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -8,6 +8,7 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import seedu.address.model.module.DistinctModuleList;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.exceptions.DuplicateModuleException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 import seedu.address.model.task.DistinctTaskList;
@@ -206,6 +207,19 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public ObservableList<Module> getModuleList() {
         return modules.getUnmodifiableModuleList();
+    }
+
+    /**
+     * Replaces the given Module {@code target} with {@code editedModule}.
+     * {@code target} must exist in the module list.
+     *
+     * @throws DuplicateModuleException if module identity of {@code editedModule} is the same as another module
+     *     in the list (other than {@code target}).
+     */
+    public void replaceModule(Module target, Module editedModule) throws DuplicateModuleException {
+        requireAllNonNull(target, editedModule);
+
+        modules.replaceModule(target, editedModule);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -20,6 +20,9 @@ public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Task> PREDICATE_SHOW_ALL_TASKS = unused -> true;
 
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Module> PREDICATE_SHOW_ALL_MODULES = unused -> true;
+
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */
@@ -145,9 +148,13 @@ public interface Model {
      */
     void deleteModule(Module target);
 
+    void replaceModule(Module target, Module editedModule);
+
     /**
      * Updates the filter of the filtered task list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredTaskList(Predicate<Task> predicate);
+
+    void updateFilteredModuleList(Predicate<Module> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -196,9 +196,23 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void updateFilteredModuleList(Predicate<Module> predicate) {
+        requireNonNull(predicate);
+        moduleFilteredList.setPredicate(predicate);
+    }
+
+    @Override
     public void deleteModule(Module target) {
         addressBook.removeModule(target);
     }
+
+    @Override
+    public void replaceModule(Module target, Module editedModule) {
+        requireAllNonNull(target, editedModule);
+
+        addressBook.replaceModule(target, editedModule);
+    }
+
 
     //================================Task Commands=====================================
     @Override

--- a/src/main/java/seedu/address/model/module/DistinctModuleList.java
+++ b/src/main/java/seedu/address/model/module/DistinctModuleList.java
@@ -63,6 +63,26 @@ public class DistinctModuleList implements Iterable<Module> {
         }
     }
 
+    /**
+     * Replaces the given task {@code target} with {@code editedModule}.
+     * {@code target} must exist in the module list.
+     *
+     * @throws DuplicateModuleException if module identity of {@code editedModule} is the same as another module
+     *     in the list (other than {@code target}).
+     */
+    public void replaceModule(Module target, Module editedModule) throws DuplicateModuleException {
+        requireAllNonNull(target, editedModule);
+
+        int index = moduleList.indexOf(target);
+        if (index == -1) {
+            throw new ModuleNotFoundException();
+        }
+        if (containsModule(editedModule) && !editedModule.isSameModuleCode(target)) {
+            throw new DuplicateModuleException();
+        }
+        moduleList.set(index, editedModule);
+    }
+
     @Override
     public Iterator<Module> iterator() {
         return moduleList.iterator();

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -2,6 +2,9 @@ package seedu.address.model.module;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.address.logic.commands.EditModuleCommand;
+
+
 /**
  * Module class represents a Module being taken.
  */
@@ -35,6 +38,17 @@ public class Module {
             return false;
         }
         return otherModule == this || otherModule.moduleCode.equals(this.moduleCode);
+    }
+
+    /**
+     * Creates and returns a {@code Module} with the details of {@code this}
+     * edited with {@code editModuleDescriptor}.
+     */
+    public Module edit(EditModuleCommand.EditModuleDescriptor editModuleDescriptor) {
+        requireNonNull(editModuleDescriptor);
+
+        ModuleCode updatedModuleCode = editModuleDescriptor.getModuleCode().orElse(this.moduleCode);
+        return new Module(updatedModuleCode);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -130,6 +130,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void updateFilteredModuleList(Predicate<Module> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }
@@ -180,6 +185,11 @@ public class AddCommandTest {
 
         @Override
         public void replaceTask(Task task, Task editedTask) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void replaceModule(Module module, Module editedModule) {
             throw new AssertionError("This method should not be called.");
         }
     }


### PR DESCRIPTION
- Added `EditModuleCommand` class and `EditModuleCommandParser` to handle the editing of modules.
- Added a method `replaceModule(Module target, Module editedModule)` to the Model interface, ModelManager class, AddressBook class and DistinctModuleList class to replace the target module with the editedModule. 
- Added a method `updateFilteredModuleList(Predicate<Module> predicate)` in the Model interface and ModelManager class to filter out modules in the filtered module list.