### PR TITLE
Change isSameModuleCode method name to isSameModule

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -14,9 +14,9 @@ public class Messages {
     public static final String MESSAGE_MODULES_LISTED_OVERVIEW = "%1$d modules listed!";
     public static final String MESSAGE_INVALID_MODULE_DISPLAYED_INDEX = "The module index provided is invalid";
     public static final String MESSAGE_INVALID_MODULE_DELETION_AS_TIED_WITH_TASK = "The module"
-            + "cannot be deleted as it is tied with an existing task";
+            + " cannot be deleted as it is tied with an existing task";
     public static final String MESSAGE_INVALID_MODULE_EDIT_AS_TIED_WITH_TASK = "The module"
-            + "cannot be edited as it is tied with an existing task";
+            + " cannot be edited as it is tied with an existing task";
     public static final String MESSAGE_INVALID_MODULE_CLEAR = "The modules cannot be cleared as task list is not empty";
     public static final String MESSAGE_DUPLICATE_TASK = "This task already exists in the task list";
     public static final String MESSAGE_MODULE_NOT_FOUND = "This module does not exist";

--- a/src/main/java/seedu/address/logic/commands/EditModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditModuleCommand.java
@@ -62,12 +62,12 @@ public class EditModuleCommand extends Command {
         Module moduleToEdit = lastShownList.get(index.getZeroBased());
         Module editedModule = moduleToEdit.edit(editModuleDescriptor);
 
-        if (model.hasTaskWithModule(moduleToEdit)) {
-            throw new CommandException(Messages.MESSAGE_INVALID_MODULE_EDIT_AS_TIED_WITH_TASK);
+        if (moduleToEdit.isSameModule(editedModule)) {
+            throw new CommandException(MESSAGE_MODULE_NOT_EDITED);
         }
 
-        if (moduleToEdit.isSameModuleCode(editedModule)) {
-            throw new CommandException(MESSAGE_MODULE_NOT_EDITED);
+        if (model.hasTaskWithModule(moduleToEdit)) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MODULE_EDIT_AS_TIED_WITH_TASK);
         }
 
         try {

--- a/src/main/java/seedu/address/model/module/DistinctModuleList.java
+++ b/src/main/java/seedu/address/model/module/DistinctModuleList.java
@@ -31,7 +31,7 @@ public class DistinctModuleList implements Iterable<Module> {
      */
     public boolean containsModule(Module module) {
         requireNonNull(module);
-        return moduleList.stream().anyMatch(module::isSameModuleCode);
+        return moduleList.stream().anyMatch(module::isSameModule);
     }
 
     /**
@@ -77,7 +77,7 @@ public class DistinctModuleList implements Iterable<Module> {
         if (index == -1) {
             throw new ModuleNotFoundException();
         }
-        if (containsModule(editedModule) && !editedModule.isSameModuleCode(target)) {
+        if (containsModule(editedModule) && !editedModule.isSameModule(target)) {
             throw new DuplicateModuleException();
         }
         moduleList.set(index, editedModule);

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -3,8 +3,6 @@ package seedu.address.model.module;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.logic.commands.EditModuleCommand;
-import seedu.address.model.task.Task;
-
 
 /**
  * Module class represents a Module being taken.
@@ -35,7 +33,7 @@ public class Module {
      *         else return false
      */
     public boolean isSameModule(Module otherModule) {
-       return this.equals(otherModule);
+        return this.equals(otherModule);
     }
 
     /**

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -3,6 +3,7 @@ package seedu.address.model.module;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.logic.commands.EditModuleCommand;
+import seedu.address.model.task.Task;
 
 
 /**
@@ -27,17 +28,14 @@ public class Module {
     }
 
     /**
-     * Checks whether two modules have the same module code.
+     * Checks whether two modules have the same data fields.
      *
      * @param otherModule The other module being compared against.
      * @return true if the two Module objects have the same module code;
      *         else return false
      */
-    public boolean isSameModuleCode(Module otherModule) {
-        if (otherModule == null) {
-            return false;
-        }
-        return otherModule == this || otherModule.moduleCode.equals(this.moduleCode);
+    public boolean isSameModule(Module otherModule) {
+       return this.equals(otherModule);
     }
 
     /**
@@ -52,9 +50,17 @@ public class Module {
     }
 
     @Override
-    public boolean equals(Object otherModule) {
-        return otherModule == this || (otherModule instanceof Module
-                && isSameModuleCode((Module) otherModule));
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Module)) {
+            return false;
+        }
+
+        Module otherModule = (Module) other;
+        return otherModule.getModuleCode().equals(getModuleCode());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/DistinctTaskList.java
+++ b/src/main/java/seedu/address/model/task/DistinctTaskList.java
@@ -37,7 +37,7 @@ public class DistinctTaskList implements Iterable<Task> {
      */
     public boolean containsModule(Module toCheck) {
         requireNonNull(toCheck);
-        return taskList.stream().map(Task::getModule).anyMatch(toCheck::isSameModuleCode);
+        return taskList.stream().map(Task::getModule).anyMatch(toCheck::isSameModule);
     }
 
     /**


### PR DESCRIPTION
Change isSameModuleCode method name in Module.java to be isSameModule to improve consistency and readability. Files affected by this name change were also modified. The editCommandModule class was changed as well to better respond to users when there is an erroneous input.