### PR TITLE
Improve edit exam command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditExamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditExamCommand.java
@@ -94,9 +94,9 @@ public class EditExamCommand extends Command {
                 Optional<ButtonType> userInput = alert.showAndWait();
 
                 if (userInput.get() == ButtonType.YES) {
-                    return changeModAndUnlinkTasks(model, examToEdit, editedExam);
+                    return editExamAndUnlinkTasks(model, examToEdit, editedExam);
                 } else {
-                    return examNotEditAfterConfirmation(model);
+                    return examNotEditedAfterConfirmation(model);
                 }
             } else {
                 return editExamWithoutUnlinkingTasks(model, examToEdit, editedExam);
@@ -106,7 +106,7 @@ public class EditExamCommand extends Command {
         }
     }
 
-    private CommandResult changeModAndUnlinkTasks(Model model, Exam examToEdit, Exam editedExam) {
+    private CommandResult editExamAndUnlinkTasks(Model model, Exam examToEdit, Exam editedExam) {
         model.replaceExam(examToEdit, editedExam, false);
         model.unlinkTasksFromExam(examToEdit);
         model.updateFilteredExamList(PREDICATE_SHOW_ALL_EXAMS);
@@ -121,7 +121,7 @@ public class EditExamCommand extends Command {
         return new CommandResult(String.format(MESSAGE_EDIT_EXAM_SUCCESS, editedExam));
     }
 
-    private CommandResult examNotEditAfterConfirmation(Model model) {
+    private CommandResult examNotEditedAfterConfirmation(Model model) {
         model.updateFilteredExamList(PREDICATE_SHOW_ALL_EXAMS);
         return new CommandResult("Exam is not edited.");
     }

--- a/src/main/java/seedu/address/logic/commands/EditExamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditExamCommand.java
@@ -86,8 +86,8 @@ public class EditExamCommand extends Command {
             if (!isEditedExamOfSameModule && model.isExamLinkedToTask(examToEdit)) {
                 Alert alert =
                         new Alert(Alert.AlertType.CONFIRMATION,
-                                "Do you want to edit the module code as " + "\n" +
-                                        "all the tasks linked to this exam will be unlinked",
+                                "Do you want to edit the module code as " + "\n"
+                                        + "all the tasks linked to this exam will be unlinked",
                                 ButtonType.YES,
                                 ButtonType.NO);
                 alert.setTitle("Confirmation");
@@ -99,7 +99,7 @@ public class EditExamCommand extends Command {
                     return examNotEditAfterConfirmation(model);
                 }
             } else {
-               return editExamWithoutUnlinkingTasks(model, examToEdit, editedExam);
+                return editExamWithoutUnlinkingTasks(model, examToEdit, editedExam);
             }
         } catch (DuplicateExamException e) {
             throw new CommandException(MESSAGE_DUPLICATE_EXAM);
@@ -110,8 +110,8 @@ public class EditExamCommand extends Command {
         model.replaceExam(examToEdit, editedExam, false);
         model.unlinkTasksFromExam(examToEdit);
         model.updateFilteredExamList(PREDICATE_SHOW_ALL_EXAMS);
-        return new CommandResult(String.format(MESSAGE_EDIT_EXAM_SUCCESS, editedExam) + "\n" +
-                "All the tasks previously linked to this exam are now unlinked.");
+        return new CommandResult(String.format(MESSAGE_EDIT_EXAM_SUCCESS, editedExam) + "\n"
+                + "All the tasks previously linked to this exam are now unlinked.");
     }
 
     private CommandResult editExamWithoutUnlinkingTasks(Model model, Exam examToEdit, Exam editedExam) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -330,6 +330,13 @@ public class AddressBook implements ReadOnlyAddressBook {
         tasks.updateExamFieldForTask(previousExam, newExam);
     }
 
+    /**
+     * Returns true if {@code examToEdit} is linked to any task, otherwise false.
+     */
+    public boolean isExamLinkedToTask(Exam examToEdit) {
+        requireNonNull(examToEdit);
+        return tasks.isExamLinkedToTask(examToEdit);
+    }
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -170,7 +170,7 @@ public interface Model {
     void unlinkTasksFromExam(Exam exam);
 
     /**
-     * Returns true if a exam with the same description and module and exam date
+     * Returns true if an exam with the same description and module and exam date
      * as {@code exam} exists in the exam list.
      */
     boolean hasExam(Exam exam);
@@ -210,4 +210,9 @@ public interface Model {
      * @param newExam The new exam which will replace the previous exam in the task's exam field.
      */
     void updateExamFieldForTask(Exam previousExam, Exam newExam);
+
+    /**
+     * Returns true if {@code examToEdit} is linked to any task, otherwise false.
+     */
+    boolean isExamLinkedToTask(Exam examToEdit);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -289,4 +289,10 @@ public class ModelManager implements Model {
         examFilteredList.setPredicate(predicate);
     }
 
+    @Override
+    public boolean isExamLinkedToTask(Exam examToEdit) {
+        requireNonNull(examToEdit);
+        return addressBook.isExamLinkedToTask(examToEdit);
+    }
+
 }

--- a/src/main/java/seedu/address/model/exam/ExamDate.java
+++ b/src/main/java/seedu/address/model/exam/ExamDate.java
@@ -18,7 +18,6 @@ public class ExamDate {
     public static final DateTimeFormatter DATE_TIME_FORMATTER =
             DateTimeFormatter.ofPattern("dd-MM-uuuu").withResolverStyle(ResolverStyle.STRICT);
     public final String examDate;
-    public final String dateWithoutFormatting;
 
 
     /**
@@ -28,8 +27,7 @@ public class ExamDate {
      */
     public ExamDate(String date) {
         requireNonNull(date);
-        examDate = LocalDate.parse(date, DATE_TIME_FORMATTER).format(DateTimeFormatter.ofPattern("d MMM yyyy"));
-        dateWithoutFormatting = date;
+        examDate = date;
     }
 
     /**

--- a/src/main/java/seedu/address/model/task/DistinctTaskList.java
+++ b/src/main/java/seedu/address/model/task/DistinctTaskList.java
@@ -108,8 +108,8 @@ public class DistinctTaskList implements Iterable<Task> {
      */
     public boolean isExamLinkedToTask(Exam exam) {
         requireNonNull(exam);
-        for(int i = 0; i < taskList.size(); i++) {
-            if(taskList.get(i).isLinked() && taskList.get(i).getExam().equals(exam)) {
+        for (int i = 0; i < taskList.size(); i++) {
+            if (taskList.get(i).isLinked() && taskList.get(i).getExam().equals(exam)) {
                 return true;
             }
         }

--- a/src/main/java/seedu/address/model/task/DistinctTaskList.java
+++ b/src/main/java/seedu/address/model/task/DistinctTaskList.java
@@ -104,6 +104,19 @@ public class DistinctTaskList implements Iterable<Task> {
     }
 
     /**
+     * Returns true if {@code examToEdit} is linked to any task, otherwise false.
+     */
+    public boolean isExamLinkedToTask(Exam exam) {
+        requireNonNull(exam);
+        for(int i = 0; i < taskList.size(); i++) {
+            if(taskList.get(i).isLinked() && taskList.get(i).getExam().equals(exam)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Replaces task by changing its given exam field from {@code previousExam}
      * to {@code newExam} for tasks that have their exam field as {@code previousExam}.
      * @param previousExam The exam in the task's exam field.

--- a/src/main/java/seedu/address/storage/JsonAdaptedExam.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedExam.java
@@ -43,7 +43,7 @@ public class JsonAdaptedExam {
     public JsonAdaptedExam(Exam exam) {
         description = exam.getDescription().description;
         moduleCode = exam.getModule().getModuleCode().moduleCode;
-        date = exam.getExamDate().dateWithoutFormatting;
+        date = exam.getExamDate().examDate;
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTask.java
@@ -70,7 +70,7 @@ public class JsonAdaptedTask {
         status = task.getStatus().status;
         priority = task.getPriorityTag() == null ? null : task.getPriorityTag().status;
         deadline = task.getDeadlineTag() == null ? null : task.getDeadlineTag().toString();
-        examDate = task.getExam() == null ? null : task.getExam().getExamDate().dateWithoutFormatting;
+        examDate = task.getExam() == null ? null : task.getExam().getExamDate().examDate;
         examDescription = task.getExam() == null ? null : task.getExam().getDescription().description;
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -188,6 +188,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean isExamLinkedToTask(Exam examToEdit) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Improve the edit command by making an alert confirmation before
the person changes the module and unlinks all the task.
Made changes to the command result.
Fix bugs for the duplicate exam exception
such that it does not unlink or update
the task before exception is thrown.
Make changes to the date format for exam such that it displays
dd-mm-yyyy for standardisation